### PR TITLE
[WIP] init SECURITY.md closes #6

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+To report a security issue, please email [security@ubuntu.com](mailto:security@ubuntu.com) with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what you can expect when you contact us and what we expect from you.
+


### PR DESCRIPTION
Please do not merge yet.

The 25.04 revision of the SSDLC SEC0026 Vulnerability Response will require that projects have a `SECURITY.md`. Many thanks to @sdcanonical for driving this :tada:

This is the current example template. Changes and finalization may occur before 25.04.